### PR TITLE
Fix resultados readability: white row backgrounds + remove undefined values

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1702,9 +1702,26 @@ body {
   align-items: center;
   gap: 0.75rem;
   padding: 0.6rem 0.75rem;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
+  background: #ffffff;
+  border: 1px solid #e0e0e0;
   border-radius: var(--radius);
+  color: #111;
+}
+
+.result-row .result-name {
+  color: #111;
+}
+
+.result-row .result-pts {
+  color: #333;
+}
+
+.result-row .champ-pts {
+  color: #111;
+}
+
+.result-row .champ-detail {
+  color: #666;
 }
 
 .result-pos {

--- a/js/resultados.js
+++ b/js/resultados.js
@@ -157,10 +157,10 @@
 
     html += '<div class="results-list mt-1">';
     results.forEach((r, i) => {
-      const driver = r.Driver;
-      const constructor = r.Constructor;
-      const ourDriver = findOurDriver(driver.driverId, driver.familyName);
-      const ourTeam = findOurTeam(constructor.constructorId);
+      const driver = r.Driver || {};
+      const constructor = r.Constructor || {};
+      const ourDriver = driver.driverId ? findOurDriver(driver.driverId, driver.familyName) : null;
+      const ourTeam = constructor.constructorId ? findOurTeam(constructor.constructorId) : null;
       const teamColor = ourTeam ? ourTeam.color : '#666';
       const imgUrl = ourDriver ? getDriverImageUrl(ourDriver) : '';
       const pts = parseInt(r.points) || 0;
@@ -168,13 +168,13 @@
 
       html += `
         <div class="result-row ${pos <= 3 ? 'result-podium result-podium-' + pos : ''}">
-          <div class="result-pos" style="background: ${teamColor}">${r.position}</div>
-          ${imgUrl ? `<img src="${imgUrl}" class="result-driver-img" alt="${driver.familyName}">` : `<div class="result-driver-placeholder"></div>`}
+          <div class="result-pos" style="background: ${teamColor}">${r.position || pos}</div>
+          ${imgUrl ? `<img src="${imgUrl}" class="result-driver-img" alt="${driver.familyName || ''}">` : `<div class="result-driver-placeholder"></div>`}
           <div class="result-info">
-            <span class="result-name">${driver.givenName} ${driver.familyName}</span>
-            <span class="result-team" style="color: ${teamColor}">${constructor.name}</span>
+            <span class="result-name">${driver.givenName || ''} ${driver.familyName || ''}</span>
+            <span class="result-team" style="color: ${teamColor}">${constructor.name || ''}</span>
           </div>
-          ${ourTeam ? renderTeamBadge(ourTeam.id, 'sm') : `<span class="team-badge-sm" style="background:${teamColor}">${constructor.constructorId.slice(0,3).toUpperCase()}</span>`}
+          ${ourTeam ? renderTeamBadge(ourTeam.id, 'sm') : `<span class="team-badge-sm" style="background:${teamColor}">${constructor.constructorId ? constructor.constructorId.slice(0,3).toUpperCase() : ''}</span>`}
           <span class="result-pts">${pts > 0 ? '+' + pts : ''}</span>
         </div>
       `;
@@ -198,7 +198,7 @@
     driverStandings.forEach((s) => {
       const driver = s.Driver;
       const constructor = s.Constructors && s.Constructors[0];
-      const ourDriver = findOurDriver(driver.driverId, driver.familyName);
+      const ourDriver = driver ? findOurDriver(driver.driverId, driver.familyName) : null;
       const ourTeam = constructor ? findOurTeam(constructor.constructorId) : null;
       const teamColor = ourTeam ? ourTeam.color : '#666';
       const imgUrl = ourDriver ? getDriverImageUrl(ourDriver) : '';
@@ -206,15 +206,15 @@
 
       html += `
         <div class="result-row">
-          <div class="result-pos champ-pos-${pos <= 3 ? pos : 'n'}">${s.position}</div>
-          ${imgUrl ? `<img src="${imgUrl}" class="result-driver-img" alt="${driver.familyName}">` : `<div class="result-driver-placeholder"></div>`}
+          <div class="result-pos champ-pos-${pos <= 3 ? pos : 'n'}">${s.position || pos}</div>
+          ${imgUrl ? `<img src="${imgUrl}" class="result-driver-img" alt="${driver ? driver.familyName : ''}">` : `<div class="result-driver-placeholder"></div>`}
           <div class="result-info">
-            <span class="result-name">${driver.givenName} ${driver.familyName}</span>
+            <span class="result-name">${driver ? driver.givenName : ''} ${driver ? driver.familyName : ''}</span>
             <span class="result-team" style="color: ${teamColor}">${constructor ? constructor.name : ''}</span>
           </div>
           <div class="champ-stats">
-            <span class="champ-pts">${s.points}</span>
-            <span class="champ-detail">${s.wins} victorias</span>
+            <span class="champ-pts">${s.points || 0}</span>
+            <span class="champ-detail">${s.wins || 0} victorias</span>
           </div>
         </div>
       `;
@@ -237,20 +237,20 @@
     let html = '<div class="results-list">';
     constructorStandings.forEach((s) => {
       const constructor = s.Constructor;
-      const ourTeam = findOurTeam(constructor.constructorId);
+      const ourTeam = constructor ? findOurTeam(constructor.constructorId) : null;
       const teamColor = ourTeam ? ourTeam.color : '#666';
       const pos = parseInt(s.position);
 
       html += `
         <div class="result-row">
-          <div class="result-pos champ-pos-${pos <= 3 ? pos : 'n'}">${s.position}</div>
-          ${ourTeam ? renderTeamBadge(ourTeam.id) : `<span class="team-badge" style="background:${teamColor}">${constructor.constructorId.slice(0,3).toUpperCase()}</span>`}
+          <div class="result-pos champ-pos-${pos <= 3 ? pos : 'n'}">${s.position || pos}</div>
+          ${ourTeam ? renderTeamBadge(ourTeam.id) : `<span class="team-badge" style="background:${teamColor}">${constructor ? constructor.constructorId.slice(0,3).toUpperCase() : ''}</span>`}
           <div class="result-info">
-            <span class="result-name">${constructor.name}</span>
+            <span class="result-name">${constructor ? constructor.name : ''}</span>
           </div>
           <div class="champ-stats">
-            <span class="champ-pts">${s.points}</span>
-            <span class="champ-detail">${s.wins} victorias</span>
+            <span class="champ-pts">${s.points || 0}</span>
+            <span class="champ-detail">${s.wins || 0} victorias</span>
           </div>
         </div>
       `;


### PR DESCRIPTION
- Changed .result-row background from dark (#262626) to white (#ffffff)
  with appropriate dark text colors for readability
- Added safety checks (|| '', || 0, || {}) for all API data interpolations
  in race results, driver championship, and constructor championship
  to prevent "undefined" text from appearing

Fixes #4

https://claude.ai/code/session_013b522stcFGHXu8XFuZgwec