### PR TITLE
Fix driver image cropping to show face instead of mid-body

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1742,6 +1742,7 @@ body {
   height: 40px;
   border-radius: var(--radius);
   object-fit: cover;
+  object-position: top;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
Added object-position: top to .result-driver-img so the crop starts from the top of the image, showing the driver's face.

Fixes #6

https://claude.ai/code/session_013b522stcFGHXu8XFuZgwec